### PR TITLE
[DO-2761] Invalid PDF file name when downloading from print tab

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -73,7 +73,23 @@ export const getPDF = (id, name, download, dataset, setLoading) => {
         fileLink.download = `${name}.pdf`;
         fileLink.click();
       } else {
-        window.open(fileURL);
+        const openPDF = () => {
+          const pdfWindow = window.open(fileURL);
+          const html = `
+            <html>
+            <head>
+              <title>${name}</title>
+            </head>
+                <embed width="100%" height="100%" src=${fileURL} type="application/pdf">
+              </body>
+            </html>
+          `;
+
+          pdfWindow.document.write(html);
+          pdfWindow.document.close();
+          pdfWindow.history.pushState(null, name, fileURL);
+        };
+        openPDF();
       }
     });
 };


### PR DESCRIPTION
This problem in all datasets - PEP, Sanctions (Person/Company/Country) with PDF print function

Steps to reproduce:
1. Open Sanctions against persons https://dp.dataocean.tk/system/datasets/person-sanction/
2. Select Elena Papachristodoulou Psintrou for a detailed view
3. Press button [Print] in header of the ride side of the page
4. Press button [Download] in header of the ride side of the page

Expected result:
file name to download should be PEp/Person/Company/Country name in out database
Actual result:
Temporary file name 